### PR TITLE
Consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ logging:
 
 - Directory used will be archived into a new directory. 
   - will have a new naming convention
-  - RT#____first_email.yaml 
+  - rt{rt_number}_first_email.yaml 
       -  1 week warning
-  - RT#____second_email.yaml 
+  - rt{rt_number}_second_email.yaml 
       -  48 hr warning
-  - RT#____final_email.yaml
+  - rt{rt_number}_final_email.yaml
       -  24 hr warning
-  - RT#_____deleted_email.yaml
+  - rt{rt_number}__deleted_email.yaml
       -  Email has now been deleted.
   
 
@@ -57,28 +57,28 @@ Example cron command:
 ## Metadata Root Layout
 
 Files will be organized by the following possible files:
-    - RT#____initial.yaml 
+    - rt{rt_number}_initial.yaml 
         - A new share has been recorded by creating this file along with its registration date.
-    - RT#____first_email.yaml
+    - rt{rt_number}_first_email.yaml
         - First email will be sent 3 weeks after the share has been registered along with the creation of this file.
-    - RT#____second_email.yaml
+    - rt{rt_number}_second_email.yaml
         - A second email will be sent 3 weeks and 4 days after registration date along with the creation of this file. 
-    - RT#____final_email.yaml
+    - rt{rt_number}_final_email.yaml
         - A final email will be sent 3 weeks and 6 days after registration date along with the creation of this file.
-    - RT#___cleanup.yaml
+    - rt{rt_number}_cleanup.yaml
         - 4 weeks after registration, a cleanup file will be created followed by the cleaning up of the directory.
 
 
 ## Shares will be categorized by the two following directories:
 
 - # active
-    - 5678_initial.yaml 
-    - 5678_first_email.yaml
+    - rt5678_initial.yaml 
+    - rt5678_first_email.yaml
     - ...
 - # archive
-    - 1234_initial.yaml
-    - 1234_first_email.yaml
-    - 1234_second_email.yaml
-    - 1234_final_email.yaml
-    - 1234_cleanup.yaml
+    - rt1234_initial.yaml
+    - rt1234_first_email.yaml
+    - rt1234_second_email.yaml
+    - rt1234_final_email.yaml
+    - rt1234_cleanup.yaml
     - ...

--- a/src/mftscleanup/cleanup.py
+++ b/src/mftscleanup/cleanup.py
@@ -34,7 +34,7 @@ def new_share(
         total_file_size=t_file_size,
         registration_date=str(start_date),
     )
-    destination = pathlib.Path(metadata_root) / "active" / f"{rt_number}_initial.yaml"
+    destination = pathlib.Path(metadata_root) / "active" / f"rt{rt_number}_initial.yaml"
     directory = destination.parent
     directory.mkdir(parents=True, exist_ok=True)
     destination.write_text(dump(payload), encoding="UTF-8")

--- a/src/mftscleanup/cleanup.py
+++ b/src/mftscleanup/cleanup.py
@@ -30,9 +30,9 @@ def new_share(
         rt_number=int(rt_number),
         share_directory=str(share_directory),
         email_addresses=email_addresses,
+        initial_date=str(start_date),
         number_of_files=no_of_files,
         total_file_size=t_file_size,
-        registration_date=str(start_date),
     )
     destination = pathlib.Path(metadata_root) / "active" / f"rt{rt_number}_initial.yaml"
     directory = destination.parent
@@ -61,16 +61,16 @@ def process_active_shares(metadata_root, from_address, email_host):
 
 def process_share(rt_share_info, today):
     print(rt_share_info)
-    registration_date = date.fromisoformat(rt_share_info.registration_date)
-    print(repr(registration_date), repr(today))
+    initial_date = date.fromisoformat(rt_share_info.initial_date)
+    print(repr(initial_date), repr(today))
 
-    if (today) - (registration_date) < timedelta(21):
+    if (today) - (initial_date) < timedelta(21):
         print("not enough time")
-    elif (today) - (registration_date) == timedelta(21):
+    elif (today) - (initial_date) == timedelta(21):
         print("yaml_file1")
-    elif (today) - (registration_date) == timedelta(25):
+    elif (today) - (initial_date) == timedelta(25):
         print("yaml_file2")
-    elif (today) - (registration_date) == timedelta(27):
+    elif (today) - (initial_date) == timedelta(27):
         print("yaml_file3")
     else:
         print("no action required")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -58,7 +58,7 @@ class FakeShare:
         self.num_bytes += len(payload)
         return dummy_file
 
-    def write_initial_yaml(self, registration_date) -> Path:
+    def write_initial_yaml(self, initial_date) -> Path:
         assert list(self.share_root.glob("*")), f"empty dir {self.share_root}"
         # TODO: Define correct behavior for empty share directory. Right now, we
         # just require that all test cases contain some data.
@@ -67,8 +67,8 @@ class FakeShare:
             f"""\
             email_addresses:
             - fake@fake.com
+            initial_date: '{initial_date}'
             number_of_files: {self.num_files}
-            registration_date: '{registration_date}'
             rt_number: {self.rt_number}
             share_directory: {self.share_root}
             total_file_size: {self.num_bytes}

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -18,7 +18,7 @@ def test_new_share_happy_path(rt1234: FakeShare):
         date(2020, 1, 1),
     )
     # Phase 3: check the results.
-    yaml_path = rt1234.scenario.active / "1234_initial.yaml"
+    yaml_path = rt1234.scenario.active / "rt1234_initial.yaml"
     assert yaml_path.is_file()
     EXPECTED_YAML = dedent(
         f"""\

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -24,8 +24,8 @@ def test_new_share_happy_path(rt1234: FakeShare):
         f"""\
         email_addresses:
         - fake@fake.com
+        initial_date: '2020-01-01'
         number_of_files: {rt1234.num_files}
-        registration_date: '2020-01-01'
         rt_number: {rt1234.rt_number}
         share_directory: {rt1234.share_root}
         total_file_size: {rt1234.num_bytes}

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -101,8 +101,8 @@ def test_metadata_fixtures(rt1234_initial: FakeShare, rt5678: FakeShare):
     assert rt1234_share_directory == str(scenario.data / "rt1234")
     assert yaml_data == {
         "email_addresses": ["fake@fake.com"],
+        "initial_date": "2020-01-01",
         "number_of_files": 1,
-        "registration_date": "2020-01-01",
         "rt_number": 1234,
         "total_file_size": 6,
     }


### PR DESCRIPTION
Fix some inconsistencies:

- Files and directories with RT numbers now always begin with "rt".
- All dates are of the form `f"{state.name}_date"`.