### PR TITLE
Redo stubs for process_active_shares

### DIFF
--- a/src/mftscleanup/email.py
+++ b/src/mftscleanup/email.py
@@ -1,0 +1,12 @@
+"""
+Email handling code. We wrap it up in an Emailer instance for better testability.
+"""
+
+
+class Emailer:
+    def __init__(self, from_address, email_host) -> None:
+        self.from_address = from_address
+        self.email_host = email_host
+
+    def send_message(self, recipients: list[str], subject: str, body: str) -> None:
+        raise NotImplementedError  # TODO


### PR DESCRIPTION
- Replace old stubs for `process_active_shares` to use use `get_active_shares` and `get_share_state`.
- Introduce sub class `Emailer` to support future testability.